### PR TITLE
Removed bug in power perturbation

### DIFF
--- a/src/simulations/PowerPerturbation.jl
+++ b/src/simulations/PowerPerturbation.jl
@@ -49,11 +49,43 @@ function simulate(pd::PowerPerturbation, powergrid, x0, timespan)
 
     # update integrator, clear error
     integrator.f = rhs(powergrid)
+    u_modified!(integrator,true)
+
+    step!(integrator, timespan[2]-pd.tspan_fault[2], true)
+
 
     solve!(integrator)
 
     return PowerGridSolution(integrator.sol, powergrid)
 end
 
+function simulate2(pd::PowerPerturbation, powergrid, x1, timespan)
+    @assert first(timespan) <= pd.tspan_fault[1] "fault cannot begin in the past"
+    @assert pd.tspan_fault[2] <= last(timespan) "fault cannot end in the future"
+    pd_powergrid = pd(powergrid)
+
+    problem = ODEProblem{true}(rhs(powergrid), x1, timespan)
+
+    function errorState(integrator)
+        sol1 = integrator.sol
+        x2 = operationpoint = find_operationpoint(pd_powergrid)
+        integrator.f = rhs(pd_powergrid)
+        integrator.u = x2
+    end
+
+    function regularState(integrator)
+        sol2 = integrator.sol
+        x3 = find_operationpoint(pd_powergrid) # Jump the state to be valid for the new system.
+        integrator.f = rhs(powergrid)
+        integrator.u = x3
+    end
+
+    cb1 = DiscreteCallback(((u,t,integrator) -> t in pd.tspan_fault[1]), errorState)
+    cb2 = DiscreteCallback(((u,t,integrator) -> t in pd.tspan_fault[2]), regularState)
+    sol = solve(problem, Rodas4(autodiff=false), callback = CallbackSet(cb1, cb2), tstops=[pd.tspan_fault[1];pd.tspan_fault[2]])
+    return PowerGridSolution(sol, powergrid)
+end
+
 export PowerPerturbation
+export simulate2
 export simulate

--- a/test/simulations/PowerPerturbation.jl
+++ b/test/simulations/PowerPerturbation.jl
@@ -1,17 +1,17 @@
 using Test: @test,@testset
-using PowerDynamics: PowerPerturbation, simulate, SwingEqLVS, StaticLine, PowerGrid, State
+using PowerDynamics: PowerPerturbation, simulate, SwingEqLVS, StaticLine, PowerGrid, State,systemsize
 
 @testset "test PowerPerturbation simulation" begin
-    nodes = [SwingEqLVS(H=1., P=-1, D=1, Ω=50, Γ=20, V=1), SwingEqLVS(H=1., P=-1, D=1, Ω=50, Γ=20, V=1)]
-    lines = [StaticLine(Y=-im, from=1, to=2)]
+    nodes = [SwingEqLVS(H=1., P=-1, D=1, Ω=50, Γ=20, V=1), SwingEqLVS(H=1., P=1, D=1, Ω=50, Γ=20, V=1)]
+    lines = [StaticLine(Y=-50*im, from=1, to=2)]
     grid = PowerGrid(nodes, lines)
     state = State(grid, rand(systemsize(grid)))
 
     sol = simulate(PowerPerturbation(
         fraction = 0.9,
         node_number = 1,
-        tspan_fault = (2.,3.)),
-        grid, state, (0., 5.))
+        tspan_fault = (0.1,1)),
+        grid, state, (0., 1.))
     @test sol != nothing
     @test sol.dqsol.retcode == :Success
 end


### PR DESCRIPTION
When running tests I realized the power perturbation the ending point in time for the power perturbation was not taking into regard but the perturbation was running for the whole simulation time span. I added another [step](https://github.com/JuliaEnergy/PowerDynamics.jl/blob/82ae6bdd7caa5acaad648941c1b72d0070408831/src/simulations/PowerPerturbation.jl#L54) for the solver to fix this.

Also the test script seemed broken. So I fixed it.