### PR TITLE
solving compat issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,7 @@ Setfield = "^0.4.0" # results in compatibility with the versions [0.4.0, 0.5.0).
 StaticArrays = "^0.11.0" # results in compatibility with the versions [0.11.0, 0.12.0).
 julia = "1" # results in compatibility with the versions [1.0.0, 2.0.0).
 
+
 [extras]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -21,19 +21,19 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-JSON = "^v0.21.0"
-Lazy = "^v0.14.0"
-LightGraphs = "^v1.3.0"
-MacroTools = "^v0.5.1"
-NLsolve = "^v4.1.0"
-NetworkDynamics = "^0.2.0"
-DiffEqBase = "^6.9.4"
-OrdinaryDiffEq = "^5.17.2"
-Parameters = "^v0.12.0"
-RecipesBase = "^v0.7.0"
-Setfield = "^v0.4.0"
-StaticArrays = "^v0.11.0"
-julia = "1"
+JSON = "^0.21.0" # results in compatibility with the versions [0.21.0, 0,22,0).
+Lazy = "^0.14.0" # results in compatibility with the versions [0.14.0, 0.15.0).
+LightGraphs = "^1.3.0" # results in compatibility with the versions [1.3.0, 2.0.0).
+MacroTools = "^0.5.1" # results in compatibility with the versions [0.5.1, 0.6.0).
+NLsolve = "^4.1.0"  # results in compatibility with the versions [4.1.0, 5.0.0).
+NetworkDynamics = "0.2,0.3"  # results in compatibility with the versions [0.2.0, 0.4.0).
+DiffEqBase = "^6.9.4"  # results in compatibility with the versions [6.9.4, 7.0.0).
+OrdinaryDiffEq = "^5.17.2"  # results in compatibility with the versions [5.7.12, 6.0.0).
+Parameters = "^0.12.0"  # results in compatibility with the versions [0.12.0, 0.13.0).
+RecipesBase = "0.7.0,0.8.0"  # results in compatibility with the versions [0.7.0, 0.9.0).
+Setfield = "^0.4.0" # results in compatibility with the versions [0.4.0, 0.5.0).
+StaticArrays = "^0.11.0" # results in compatibility with the versions [0.11.0, 0.12.0).
+julia = "1" # results in compatibility with the versions [1.0.0, 2.0.0).
 
 [extras]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"


### PR DESCRIPTION
Since we had some compat issues as described in [Issue 84](https://github.com/JuliaEnergy/PowerDynamics.jl/issues/84) and [Issue 89](https://github.com/JuliaEnergy/PowerDynamics.jl/issues/89) I reviewed the compat specifications and adjusted the Project.toml https://julialang.github.io/Pkg.jl/v1/compatibility/index.html
I added some [comments](https://github.com/JuliaEnergy/PowerDynamics.jl/blob/249d1e1534abfbaeff10aa609ccdb10a394b5edc/Project.toml#L24) next to the compat section to show which package versions the current PowerDynamics master should be compatible with. Please note that zero-leading versions are treated different from other versions since more breaking changes are expected in the early development stages of packages.
I hope, this fixes Issue 84 and 89. Please comment.