### PR TITLE
autodiff=true

### DIFF
--- a/src/simulations/NodeShortCircuit.jl
+++ b/src/simulations/NodeShortCircuit.jl
@@ -71,7 +71,7 @@ function simulate(nsc::NodeShortCircuit, powergrid, x1, timespan)
 
     cb1 = DiscreteCallback(((u,t,integrator) -> t in nsc.tspan_fault[1]), errorState)
     cb2 = DiscreteCallback(((u,t,integrator) -> t in nsc.tspan_fault[2]), regularState)
-    sol = solve(problem, Rodas4(autodiff=false), force_dtmin = true, callback = CallbackSet(cb1, cb2), tstops=[t1, t2])
+    sol = solve(problem, Rodas4(), force_dtmin = true, callback = CallbackSet(cb1, cb2), tstops=[t1, t2])
     return PowerGridSolution(sol, powergrid)
 end
 

--- a/src/simulations/PowerPerturbation.jl
+++ b/src/simulations/PowerPerturbation.jl
@@ -61,7 +61,7 @@ function simulate(pd::PowerPerturbation, powergrid, x0, timespan)
     t3=pd.tspan_fault[2]-dt_fault
     t4=pd.tspan_fault[2]+dt_fault
 
-    integrator = init(problem, Rodas4(autodiff=false),tstops=[t1,t2,t3,t4])
+    integrator = init(problem, Rodas4(),tstops=[t1,t2,t3,t4])
 
     step!(integrator, pd.tspan_fault[1], true)
 

--- a/src/simulations/simulations.jl
+++ b/src/simulations/simulations.jl
@@ -86,7 +86,7 @@ end
 
 function solve(pg::PowerGrid, x0, timespan)
     problem = ODEProblem{iipfunc}(rhs(pg),x0.vec,timespan)
-    solution = solve(problem, Rodas4(autodiff=false))
+    solution = solve(problem, Rodas4())
     PowerGridSolution(solution, pg)
 end
 


### PR DESCRIPTION
Since version `0.2` NetworkDynamics supports automatic differentiation. This restriction can be removed. All tests pass.