### PR TITLE
fixing bug in simulate of AbstractPerturbation and in find_operationpoint

### DIFF
--- a/src/faults/AbstractPerturbation.jl
+++ b/src/faults/AbstractPerturbation.jl
@@ -32,7 +32,7 @@ simulate(no::AbstractPerturbation, powergrid, x1, timespan)
 ```
 Simulates a [`AbstractPerturbation`](@ref)
 """
-function simulate(np::AbstractPerturbation, powergrid::PowerGrid, x1, timespan; solve_kwargs...)
+function simulate(np::AbstractPerturbation, powergrid::PowerGrid, x1::Array, timespan; solve_kwargs...)
     @assert first(timespan) <= np.tspan_fault[1] "fault cannot begin in the past"
     @assert np.tspan_fault[2] <= last(timespan) "fault cannot end in the future"
 
@@ -66,6 +66,8 @@ function simulate(np::AbstractPerturbation, powergrid::PowerGrid, x1, timespan; 
 end
 
 simulate(np::AbstractPerturbation, op::State, timespan) = simulate(np, op.grid, op.vec, timespan)
+simulate(np::AbstractPerturbation, powergrid::PowerGrid,op::State, timespan) = simulate(np, powergrid, op.vec, timespan)
+
 
 "Error to be thrown if something goes wrong during power perturbation"
 struct FieldUpdateError <: PowerDynamicsError

--- a/src/faults/ChangeInitialConditions.jl
+++ b/src/faults/ChangeInitialConditions.jl
@@ -51,7 +51,7 @@ simulate(p::ChangeInitialConditions, powergrid, x0; timespan)
 ```
 Simulates a [`ChangeInitialConditions`](@ref)
 """
-function simulate(p::ChangeInitialConditions, powergrid, x0::State; timespan)
+function simulate(p::ChangeInitialConditions, powergrid, x0::State, timespan; solve_kwargs...)
     solve(powergrid, p(x0), timespan);
 end
 

--- a/src/operationpoint/operationpoint.jl
+++ b/src/operationpoint/operationpoint.jl
@@ -20,7 +20,7 @@ function initial_guess(pg)
         @warn "There is no slack bus in the system to balance powers. Default voltage guess: u = 1 + 0j [pu]."
         voltage_guess = complex(1.0, 0.0)
     else
-        sl = findfirst(SlackAlgebraic ∈ collect(values(pg.nodes)) .|> typeof)
+        sl = findfirst(collect(values(pg.nodes).|> typeof).== SlackAlgebraic)
         bus_array=collect(values(pg.nodes))
         slack = bus_array[sl]
         voltage_guess = slack.U

--- a/test/faults/AbstractPerturbation.jl
+++ b/test/faults/AbstractPerturbation.jl
@@ -1,6 +1,6 @@
 using Test: @test
 using LightGraphs: edges, Edge, SimpleGraph
-using PowerDynamics: SlackAlgebraic, SwingEqLVS, StaticLine, ChangeInitialConditions, Inc, Dec, simulate, PowerGrid, State
+using PowerDynamics: SlackAlgebraic, SwingEqLVS, StaticLine, ChangeInitialConditions, Inc, Dec, simulate, PowerGrid, State, AbstractPerturbation
 
 graph = SimpleGraph(2)
 Y = 0 + 5*im
@@ -12,12 +12,18 @@ omega1 = 0.01
 omega1_delta = 0.2
 state = State(grid, [real(u_Sl), imag(u_Sl), real(u_Sw1), imag(u_Sw1), omega1, real(u_Sw2), imag(u_Sw2), -omega1])
 
-state2 = ChangeInitialConditions(2, :ω, Inc(omega1_delta))(state)
-@test state2[2, :ω] == omega1 + omega1_delta
+Base.@kwdef struct DummyPerturbation<:AbstractPerturbation
+    tspan_fault
+end
 
-state3 = ChangeInitialConditions(2, :ω, Dec(omega1_delta))(state)
-@test state3[2, :ω] == omega1 - omega1_delta
+function (dp::DummyPerturbation)(powergrid)
+    powergrid
+end
 
-sol = simulate(ChangeInitialConditions(2, :ω, Inc(omega1_delta)),grid,state,(0,0.1))
+sol = simulate(DummyPerturbation(tspan_fault=(0.,0.1)),grid,state,(0,0.1))
+@test sol !== nothing
+@test sol.dqsol.retcode == :Success
+
+sol = simulate(DummyPerturbation(tspan_fault=(0.,0.1)),state,(0,0.1))
 @test sol !== nothing
 @test sol.dqsol.retcode == :Success

--- a/test/operationpoint/operationpoint.jl
+++ b/test/operationpoint/operationpoint.jl
@@ -17,8 +17,8 @@ begin
     V = 1.
 
     nodes = [
-        SlackAlgebraic(U = U1),
         PQAlgebraic(P = P2, Q = Q2),
+        SlackAlgebraic(U = U1),
         CSIMinimal(I_r = I_r),
         SwingEqLVS(H = H, P = P, D = D, Ω = Ω, Γ = Γ, V = V),
     ]
@@ -40,14 +40,14 @@ end
     @test PowerDynamics.initial_guess(grid) == expected_guess
     @test PowerDynamics.initial_guess(grid, v) == expected_guess
 
-    v[1] *= 0.9
+    v[2] *= 0.9
 
     @test_throws AssertionError PowerDynamics.initial_guess(grid, v)
 end
 
 @testset "test for slack warning and SwingEq" begin
     no_slack = copy(nodes)
-    no_slack[1] = PQAlgebraic(P=0., Q=0.)
+    no_slack[2] = PQAlgebraic(P=0., Q=0.)
     @test_logs (
         :warn,
         "There is no slack bus in the system to balance powers. Default voltage guess: u = 1 + 0j [pu].",
@@ -69,6 +69,35 @@ end
     with_swing = copy(nodes)
     with_swing[end] = SwingEq(H = H, P = P, D = D, Ω = Ω)
     @test_throws OperationPointError find_operationpoint(PowerGrid(with_swing, lines))
+end
+
+# define small test system
+begin
+    U1 = complex(1.0)
+    P2 = -1.0
+    Q2 = 0.0
+    Y = 20f0im
+    I_r = complex(0.5)
+    H = 1.0
+    P = 1.0
+    D = 10.
+    Ω = 2π*50
+    Γ = 100.
+    V = 1.
+
+    nodes = [
+        SlackAlgebraic(U = U1),
+        PQAlgebraic(P = P2, Q = Q2),
+        CSIMinimal(I_r = I_r),
+        SwingEqLVS(H = H, P = P, D = D, Ω = Ω, Γ = Γ, V = V),
+    ]
+    lines = [
+        StaticLine(from = 1, to = 2, Y = Y),
+        StaticLine(from = 2, to = 3, Y = Y),
+        StaticLine(from = 3, to = 4, Y = Y),
+    ]
+
+    grid = PowerGrid(nodes, lines)
 end
 
 @testset "check found operationpoint" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ testlist = [
     ("lines/PiModelLine.jl", "PiModelLine tests"),
     ("lines/RLLine.jl", "RLLine tests"),
     ("lines/Transformer.jl", "Transformer tests"),
+    ("faults/AbstractPerturbation.jl", "AbstractPerturbation Tests"),
     ("faults/ChangeInitialConditions.jl", "ChangeInitialConditions Tests"),
     ("faults/NodeParameterChange.jl", "NodeParameterChange Tests"),
     ("faults/LineFailure.jl", "LineFailure Tests"),


### PR DESCRIPTION
There was a small bug in the simulate function of the AbstractPerturbation that I fixed. Also I added a test for the AbstractPerturbation.jl to make sure the simulate function is working correctly as usual for both `simulate(np::AbstractPerturbation, op::State, timespan)` and `simulate(np::AbstractPerturbation, powergrid::PowerGrid,op::State, timespan)`

Also the `initial_guess(pg)` in operationpoint.jl calculated the indices of the slack bus incorrectly. It was always 1. I made sure this does not happen again by changing the test such that the slack bus is not always the first in the list.
