### PR TITLE
Use Diagonal type for mass matrices

### DIFF
--- a/src/nodes/NodeMacro.jl
+++ b/src/nodes/NodeMacro.jl
@@ -216,5 +216,5 @@ creates a mass matrix with all masses turned off.
 function MassMatrix(;m_u::Bool = false, m_int = no_internal_masses)
     mm = [m_u, m_u] # double mass for u, because it is a complex variable
     append!(mm, m_int)
-    return mm .|> Int
+    return mm .|> Int |> Diagonal
 end

--- a/src/nodes/experimental/CompositeNode.jl
+++ b/src/nodes/experimental/CompositeNode.jl
@@ -133,10 +133,10 @@ function construct_vertex(cn::CompositeNode{T}) where T <: Union{_IPU, _IU, _PU}
     cfs = [n.f! for n in current_vertices]
     pfs = [n.f! for n in power_vertices]
 
-    mms = [vert.mass_matrix == I ? vert.mass_matrix * ones(Int, vert.dim) : vert.mass_matrix for vert in all_vertices]
+    mms = [vert.mass_matrix == I ? vert.mass_matrix * ones(Int, vert.dim) : diag(vert.mass_matrix) for vert in all_vertices]
 
     #  and the corresponding masses for the internal variables of all vertices
-    mass_matrix = vcat(mms[end][1:2], [mm[3:end] for mm in mms]...)
+    mass_matrix = vcat(mms[end][1:2], [mm[3:end] for mm in mms]...) |> Diagonal
 
     num_cv = length(current_vertices)
     num_pv = length(power_vertices)
@@ -197,12 +197,12 @@ function construct_vertex(cn::CompositeNode{T}) where T <: Union{_IP, _I, _P}
     cfs = [n.f! for n in current_vertices]
     pfs = [n.f! for n in power_vertices]
 
-    mms = [vert.mass_matrix == I ? vert.mass_matrix * ones(Int, vert.dim) : vert.mass_matrix for vert in all_vertices]
+    mms = [vert.mass_matrix == I ? vert.mass_matrix * ones(Int, vert.dim) : diag(vert.mass_matrix) for vert in all_vertices]
 
     # Since there is no U-vertex, we construct a complex constraint and
     # set the first two entries to 0. The remaining entries are the
     # corresponding masses for the internal variables of all vertices.
-    mass_matrix = vcat([0, 0], [mm[3:end] for mm in mms]...)
+    mass_matrix = vcat([0, 0], [mm[3:end] for mm in mms]...) |> Diagonal
 
     num_cv = length(current_vertices)
     num_pv = length(power_vertices)

--- a/test/nodes/CurrentSourceInverterMinimal.jl
+++ b/test/nodes/CurrentSourceInverterMinimal.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: CSIMinimal, construct_vertex, symbolsof
+using LinearAlgebra: diag
 
 @testset "CSIMinimal" begin
     I_r = rand(1.0:10.0)
@@ -7,7 +8,7 @@ using PowerDynamics: CSIMinimal, construct_vertex, symbolsof
     CSI_min_vertex= construct_vertex(CSI_min)
 
     @test symbolsof(CSI_min) == [:u_r, :u_i]
-    @test CSI_min_vertex.mass_matrix == [0,0]
+    @test CSI_min_vertex.mass_matrix |> diag == [0,0]
 
     smoketest_rhs(CSI_min_vertex)
 end

--- a/test/nodes/ExponentialRecoveryLoad.jl
+++ b/test/nodes/ExponentialRecoveryLoad.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: ExponentialRecoveryLoad, construct_vertex, symbolsof
+using LinearAlgebra: diag
 
 include("NodeTestBase.jl")
 
@@ -12,7 +13,7 @@ include("NodeTestBase.jl")
     exprec_vertex= construct_vertex(exponentialRecoveryLoad)
 
     @test symbolsof(exponentialRecoveryLoad) == [:u_r, :u_i, :x_p, :x_q]
-    @test exprec_vertex.mass_matrix == [0,0,1,1]
+    @test exprec_vertex.mass_matrix |> diag == [0,0,1,1]
 
     smoketest_rhs(exprec_vertex, int_x=[x_p,x_q], int_dx=[dx_p, dx_q])
 end

--- a/test/nodes/PQAlgebraic.jl
+++ b/test/nodes/PQAlgebraic.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: PQAlgebraic, construct_vertex, symbolsof
+using LinearAlgebra: diag
 
 include("NodeTestBase.jl")
 
@@ -8,7 +9,7 @@ include("NodeTestBase.jl")
     pq = PQAlgebraic(P=P,Q=Q)
     pq_vertex = construct_vertex(pq)
     @test symbolsof(pq) == [:u_r, :u_i]
-    @test pq_vertex.mass_matrix == [0,0]
+    @test pq_vertex.mass_matrix |> diag == [0,0]
 
     smoketest_rhs(pq_vertex)
 end

--- a/test/nodes/PVAlgebraic.jl
+++ b/test/nodes/PVAlgebraic.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: PVAlgebraic, construct_vertex, symbolsof
+using LinearAlgebra: diag
 
 include("NodeTestBase.jl")
 
@@ -10,7 +11,7 @@ include("NodeTestBase.jl")
     pv = PVAlgebraic(P=P, V=V)
     pv_vertex = construct_vertex(pv)
     @test symbolsof(pv) == [:u_r, :u_i]
-    @test pv_vertex.mass_matrix == [0,0]
+    @test pv_vertex.mass_matrix |> diag == [0,0]
 
     smoketest_rhs(pv_vertex)
 end

--- a/test/nodes/SlackAlgebraic.jl
+++ b/test/nodes/SlackAlgebraic.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: SlackAlgebraic, construct_vertex, symbolsof
+using LinearAlgebra: diag
 
 include("NodeTestBase.jl")
 
@@ -9,7 +10,7 @@ include("NodeTestBase.jl")
     slack_vertex = construct_vertex(slack)
 
     @test symbolsof(slack) == [:u_r, :u_i]
-    @test slack_vertex.mass_matrix == [0,0]
+    @test slack_vertex.mass_matrix |> diag == [0,0]
 
     smoketest_rhs(slack_vertex)
 end

--- a/test/nodes/VoltageDependentLoad.jl
+++ b/test/nodes/VoltageDependentLoad.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: PQAlgebraic, SlackAlgebraic, StaticLine, VoltageDependentLoad, construct_vertex, symbolsof, find_operationpoint, PowerGrid
+using LinearAlgebra: diag
 
 include("NodeTestBase.jl")
 
@@ -11,7 +12,7 @@ include("NodeTestBase.jl")
     load = VoltageDependentLoad(P = P, Q = Q, U = U, A = A, B = B)
     load_vertex = construct_vertex(load)
     @test symbolsof(load) == [:u_r, :u_i]
-    @test load_vertex.mass_matrix == [0,0]
+    @test load_vertex.mass_matrix |> diag == [0,0]
 
     smoketest_rhs(load_vertex)
 end

--- a/test/nodes/experimental/CompositeNode.jl
+++ b/test/nodes/experimental/CompositeNode.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: CompositeNode, CSIMinimal, VSIMinimal, PQAlgebraic, construct_vertex, symbolsof
+using LinearAlgebra: diag
 
 include("../NodeTestBase.jl")
 
@@ -27,7 +28,7 @@ include("../NodeTestBase.jl")
     comp_vertex = construct_vertex(comp_node)
 
     @test symbolsof(comp_node) == [:u_r, :u_i, :ω]
-    @test comp_vertex.mass_matrix == [1,1,1]
+    @test comp_vertex.mass_matrix |> diag == [1,1,1]
 
     smoketest_rhs(comp_vertex, int_x=omega, int_dx=domega)
     # smoketest not compatible with internal variables?
@@ -38,7 +39,7 @@ include("../NodeTestBase.jl")
     comp_vertex_2 = construct_vertex(comp_node_2)
 
     @test symbolsof(comp_node_2) == [:u_r, :u_i]
-    @test comp_vertex_2.mass_matrix == [0,0]
+    @test comp_vertex_2.mass_matrix |> diag == [0,0]
 
     smoketest_rhs(comp_vertex_2)
 end

--- a/test/nodes/experimental/CurtailedPowerPlantWithInertia.jl
+++ b/test/nodes/experimental/CurtailedPowerPlantWithInertia.jl
@@ -1,6 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: CurtailedPowerPlantWithInertia, construct_vertex, symbolsof
-using LinearAlgebra: I
+using LinearAlgebra: I, diag
 
 include("../NodeTestBase.jl")
 
@@ -18,7 +18,7 @@ include("../NodeTestBase.jl")
     curtailed_pp_vertex = construct_vertex(curtailed_pp)
 
     @test symbolsof(curtailed_pp) == [:u_r,:u_i,:θ_PLL,:e_Iω, :ω,:y,:e_Iiq,:e_Iid]
-    @test curtailed_pp_vertex.mass_matrix == [0,0,1,1,1,1,1,1]
+    @test curtailed_pp_vertex.mass_matrix |> diag == [0,0,1,1,1,1,1,1]
 
     smoketest_rhs(curtailed_pp_vertex, int_x=[θ_PLL,e_Iω, ω,y,e_Iiq,e_Iid], int_dx=[dθ_PLL,de_Iω, dω,dy,de_Iiq,de_Iid])
 end

--- a/test/nodes/experimental/PVInverterWithFrequencyControl.jl
+++ b/test/nodes/experimental/PVInverterWithFrequencyControl.jl
@@ -1,6 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: PVInverterWithFrequencyControl, construct_vertex, symbolsof
-using LinearAlgebra: I
+using LinearAlgebra: I, diag
 
 include("../NodeTestBase.jl")
 
@@ -17,7 +17,7 @@ include("../NodeTestBase.jl")
     pv_inverter_vertex = construct_vertex(pv_inverter)
 
     @test symbolsof(pv_inverter) == [:u_r, :u_i,:θ_PLL,:v_xm,:v_ym,:P,:ω]
-    @test pv_inverter_vertex.mass_matrix == [0,0,1,1,1,1,1]
+    @test pv_inverter_vertex.mass_matrix |> diag == [0,0,1,1,1,1,1]
 
     smoketest_rhs(pv_inverter_vertex, int_x=[omega,theta_PLL, v_xm, v_ym, P, ω], int_dx=[domega, dtheta_PLL, dvx_m, dv_ym, dP,dω])
 end

--- a/test/nodes/experimental/RLCLoad.jl
+++ b/test/nodes/experimental/RLCLoad.jl
@@ -1,5 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: RLCLoad, construct_vertex, symbolsof
+using LinearAlgebra: diag
 
 include("../NodeTestBase.jl")
 
@@ -11,7 +12,7 @@ include("../NodeTestBase.jl")
     pv = RLCLoad(R=R, L=L, C=C)
     pv_vertex = construct_vertex(pv)
     @test symbolsof(pv) == [:u_r, :u_i, :u_Cr, :u_Ci, :i_Lr,:i_Li, :ω]
-    @test pv_vertex.mass_matrix == [0,0,1,1,1,1,1]
+    @test pv_vertex.mass_matrix |> diag == [0,0,1,1,1,1,1]
 
     smoketest_rhs(pv_vertex, int_x=[u_Cr, u_Ci, i_Lr,i_Li, omega], int_dx=[domega, du_Cr,du_Ci, di_Lr,di_Li])
 end

--- a/test/nodes/experimental/WindTurbineGenType4.jl
+++ b/test/nodes/experimental/WindTurbineGenType4.jl
@@ -1,6 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: WindTurbineGenType4, construct_vertex, symbolsof
-using LinearAlgebra: I
+using LinearAlgebra: I, diag
 
 include("../NodeTestBase.jl")
 
@@ -17,7 +17,7 @@ include("../NodeTestBase.jl")
     wind_gen_vertex = construct_vertex(wind_gen)
 
     @test symbolsof(wind_gen) == [:u_r,:u_i,:θ_PLL,:ω,:e_Idθ,:i_d]
-    @test wind_gen_vertex.mass_matrix == [0,0,1,1,1,1]
+    @test wind_gen_vertex.mass_matrix |> diag == [0,0,1,1,1,1]
 
     smoketest_rhs(wind_gen_vertex, int_x=[θ_PLL,e_Idθ,i_d, ω], int_dx=[dθ_PLL,de_Idθ,di_d, dω])
 end

--- a/test/nodes/experimental/WindTurbineGenType4_RotorControl.jl
+++ b/test/nodes/experimental/WindTurbineGenType4_RotorControl.jl
@@ -1,6 +1,6 @@
 using Test: @testset, @test
 using PowerDynamics: WindTurbineGenType4_RotorControl, construct_vertex, symbolsof
-using LinearAlgebra: I
+using LinearAlgebra: I, diag
 
 include("../NodeTestBase.jl")
 #T_L,K_dbr,T_H,K_ω,K_PLL,Q_ref,C,J,P,ω_rref,u_dcref,K_Q,K_v,K_pv,K_iv,K_ptrq,K_itrq
@@ -18,7 +18,7 @@ include("../NodeTestBase.jl")
     wind_gen_vertex = construct_vertex(wind_gen)
 
     @test symbolsof(wind_gen) == [:u_r,:u_i,:θ_PLL,:e_Idθ,:ω,:e_IP,:z,:e_IV,:u_dc,:i_q,:u_tref,:ω_r]
-    @test wind_gen_vertex.mass_matrix == [0,0,1,1,1,1,1,1,1,1,1,1]
+    @test wind_gen_vertex.mass_matrix |> diag == [0,0,1,1,1,1,1,1,1,1,1,1]
 
     smoketest_rhs(wind_gen_vertex, int_x=[θ_PLL,e_Idθ,e_Idθ,ω,e_IP,z,e_IV,u_dc,i_q,u_tref,ω_r], int_dx=[dθ_PLL,de_Idθ,de_Idθ,dω,de_IP,dz,de_IV,du_dc,di_q,du_tref,dω_r])
 end


### PR DESCRIPTION
I adjusted the code such that the mass matrices are not 1D arrays but 2D matrices of type `Diagonal`.
This ensures compatibility with `NetworkDynamics` <= v0.4.0 .