### PR TITLE
Rename xlabel -> xguide

### DIFF
--- a/src/common/PowerGridSolutions.jl
+++ b/src/common/PowerGridSolutions.jl
@@ -203,7 +203,7 @@ end
     else
         label --> tslabel(sym, n)
     end
-    xlabel --> "t"
+    xguide --> "t"
     t = tspan(sol, tres)
     println(t)
     t, tstransform(sol(t, n, sym, args...))

--- a/src/nodes/CurrentSourceInverterMinimal.jl
+++ b/src/nodes/CurrentSourceInverterMinimal.jl
@@ -10,6 +10,7 @@ most simple representation of an inverter in grid-feeding mode, according to
 Rocabert, Joan, et al. "Control of power converters in AC microgrids." (2012).
 Here, additionally to `u`, there are no internal dynamic variables.
 
+
 # Keyword Arguments
 - `I_r`: reference/ desired current
 

--- a/src/nodes/CurrentSourceInverterMinimal.jl
+++ b/src/nodes/CurrentSourceInverterMinimal.jl
@@ -10,7 +10,6 @@ most simple representation of an inverter in grid-feeding mode, according to
 Rocabert, Joan, et al. "Control of power converters in AC microgrids." (2012).
 Here, additionally to `u`, there are no internal dynamic variables.
 
-
 # Keyword Arguments
 - `I_r`: reference/ desired current
 


### PR DESCRIPTION
This PR removes the warning
```julia
┌ Warning: Attribute alias `xlabel` detected in the user recipe defined for the signature (::PowerGridSolution, ::UnitRange{Int64}, ::Symbol). To ensure expected behavior it is recommended to use the default attribute `xguide`.
└ @ Plots ~/.julia/packages/Plots/D7Ica/src/pipeline.jl:15
```
when using the recipe fora `PowerGridSolution`.