### PR TITLE
Adjust `systemsize` function for systems with dynamic lines

### DIFF
--- a/src/common/PowerGrid.jl
+++ b/src/common/PowerGrid.jl
@@ -112,4 +112,4 @@ end
 """
 Returns the total size of dynamical variables of the whole powergrid
 """
-@views systemsize(pg::PowerGrid) = sum(map(n -> dimension(n), collect(values(pg.nodes))))
+@views systemsize(pg::PowerGrid) = sum(map(n -> dimension(n), collect(values(pg.nodes)))) + sum(map(n -> dimension(n), collect(values(pg.lines))))

--- a/src/lines/LineMacro.jl
+++ b/src/lines/LineMacro.jl
@@ -74,3 +74,6 @@ function create(typedef, prep, func_body)
     append!(mainex.args, [showex])
     return esc(mainex)
 end
+
+# By default we assume static lines. For dynamic lines a dimension method for the specific type has to be implemented.
+dimension(::AbstractLine) = 0

--- a/test/lines/RLLine.jl
+++ b/test/lines/RLLine.jl
@@ -112,10 +112,6 @@ using NetworkDynamics: find_valid_ic
 
 # extend to account for line variables
 import PowerDynamics: systemsize, dimension, AbstractLine
-dimension(::AbstractLine) = 0
-systemsize(pg::PowerGrid) =
-        sum(map(n -> dimension(n), collect(values(pg.nodes)))) +
-        sum(map(n -> dimension(n), collect(values(pg.lines))))
 
 @testset "Do static and dynamics solutions agree for Slack & Swing" begin
 


### PR DESCRIPTION
When there are dynamic lines in the system, the dimension of the line states have to be considered in `systemsize`. In #147 there we made a quick fix for this. I moved this from `test` to `src` now.