### PR TITLE
Build docs on 1.6, enable authentication of worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.5'
+          version: '1.6'
       #- run: |
       #    git config --global user.name name
       #    git config --global user.email email
@@ -62,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
-        #env:
-        #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-        #  DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
Fixes https://github.com/JuliaEnergy/PowerDynamics.jl/issues/85 via https://github.com/JuliaDocs/Documenter.jl/issues/1374.

Besides, the docs haven't been rebuild since end of last year, probably due to missing priviliges of the GitHub worker. I just uncommented the respective lines and hope this works.