### PR TITLE
incorrect DAE initialisation in abstract pertubation

### DIFF
--- a/src/faults/AbstractPerturbation.jl
+++ b/src/faults/AbstractPerturbation.jl
@@ -46,7 +46,6 @@ Simulates a [`AbstractPerturbation`](@ref)
 """
 function simulate(np::AbstractPerturbation, powergrid::PowerGrid, x1::Array, timespan; solve_kwargs...)
     @assert first(timespan) <= np.tspan_fault[1] "fault cannot begin in the past"
-    @assert np.tspan_fault[2] <= last(timespan) "fault cannot end in the future"
 
     np_powergrid = np(powergrid)
     regular = rhs(powergrid)


### PR DESCRIPTION
The current implementation of `simulate` an `AbstractPertubation` calls `find_valid_initial_condition` inside the callback. This is a bad idea because it isn't a smart projection back onto the manifold constrained by a DAE problem. This was causing weird jumps of differentiable variables in the MTK integration #145. (The default init algorithm preserves continuity of all differentiable variables, only fiddeling with the constraints)

I thought this is an easy fix, sadly there are some errors in short circuit tests...