### PR TITLE
LineFault deprecation

### DIFF
--- a/src/faults/LineFailure.jl
+++ b/src/faults/LineFailure.jl
@@ -7,43 +7,6 @@ function filter_lines(lines::Array, line_name)
     copy(lines[1:end.!=line_name])
 end
 
-## LineFault -> deprecation
-
-"""
-```Julia
-LineFault(;from,to)
-```
-The arguments `from` and `to` specify the line that should be disconnected from the grid.
-"""
-struct LineFault
-    from::Any
-    to::Any
-    LineFault(; from = from, to = to) = new(from, to)
-    @warn "This implementation of a line fault will be deprecated soon. Please use LineFailure instead."
-end
-
-function (lf::LineFault)(powergrid)
-    @assert lf.from < lf.to "order important to remove the line from powergrid"
-    filtered_lines =
-        filter(l -> (l.from != lf.from || l.to != lf.to), copy(powergrid.lines))
-    PowerGrid(powergrid.nodes, filtered_lines)
-end
-
-"""
-```Julia
-simulate(lf::LineFault, powergrid, x0; timespan)
-```
-Simulates a [`LineFault`](@ref)
-"""
-function simulate(lf::LineFault, powergrid, x0; timespan)
-    solve(lf(powergrid), x0, timespan)
-end
-
-function simulate(lf::LineFault, x0::State; timespan)
-    solve(lf(x0.grid), x0.vec, timespan)
-end
-
-## LineFailure
 
 @doc """
 ```Julia
@@ -65,8 +28,5 @@ function (lf::LineFailure)(powergrid)
 end
 
 
-
-
-export LineFault
 export LineFailure
 export simulate

--- a/test/faults/LineFailure.jl
+++ b/test/faults/LineFailure.jl
@@ -1,23 +1,12 @@
 using Test: @test
 using LightGraphs: edges, Edge
-using PowerDynamics: SlackAlgebraic, SwingEqLVS, StaticLine, LineFailure,LineFault, simulate, PowerGrid, systemsize, State
+using PowerDynamics: SlackAlgebraic, SwingEqLVS, StaticLine, LineFailure, simulate, PowerGrid, systemsize, State
 using OrderedCollections: OrderedDict
 
 Y = 0 + 5*im
 nodes = [SlackAlgebraic(U=1), SwingEqLVS(H=1, P=-1, D=1, Ω=50, Γ=20, V=1), SwingEqLVS(H=1, P=-1, D=1, Ω=50, Γ=20, V=1)]
 lines = [StaticLine(from=1, to=2, Y=Y),StaticLine(from=2, to=3, Y=Y)]
 grid = PowerGrid(nodes, lines)
-
-linefault = LineFault(;from=1, to=2)
-faulty_grid = linefault(grid)
-
-@test length(faulty_grid.lines) == 1
-@test collect(edges(faulty_grid.graph)) == [Edge(2,3)]
-
-x0 = State(grid, ones(systemsize(grid)))
-sol = simulate(linefault,grid,x0,timespan=(0,0.2))
-@test sol !== nothing
-@test sol.dqsol.retcode == :Success
 
 linefailure = LineFailure(;line_name=1,tspan_fault=(0,0.1))
 faulty_grid = linefailure(grid)


### PR DESCRIPTION
For the next breaking release we can finally drop the `LineFault` method that has been replaced by `LineFailure`.