### PR TITLE
update compate helper script

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,20 +6,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.2.0]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  CompatHelper:
+    runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
It seems like our CompatHelper workflow is out of date (for example it uses Julia 1.2).

I've changed it according the [current template](https://github.com/invenia/PkgTemplates.jl/blob/master/templates/github/workflows/CompatHelper.yml) in `PkgTemplates.jl`.

~I'm not completely sure about that, since I don't know Github actions well....~
I've triggerd the workflow [manually](https://github.com/JuliaEnergy/PowerDynamics.jl/runs/4531632453?check_suite_focus=true) and it seems like it worked as expected. Now it understands the `0.4-0.9` style compat entries.