### PR TITLE
Y -> y for PiModel + Transformer in powerflow calc

### DIFF
--- a/src/operationpoint/power_flow.jl
+++ b/src/operationpoint/power_flow.jl
@@ -218,23 +218,23 @@ function make_branch_ac!(data::Dict{String,Any}, dict::Dict{Any, Int}, line::Tra
     branch_dict = _make_branch_ac_header(data, dict, line)
     branch_dict["transformer"] = true
     branch_dict["tap"] = line.t_ratio
-    branch_dict["br_r"] = real(1 / line.Y)
-    branch_dict["br_x"] = imag(1 / line.Y)
+    branch_dict["br_r"] = real(1 / line.y)
+    branch_dict["br_x"] = imag(1 / line.y)
 end
 
 function make_branch_ac!(data::Dict{String,Any}, dict::Dict{Any, Int}, line::PiModelLine)
     branch_dict = _make_branch_ac_header(data, dict, line)
     branch_dict["g_fr"] = real(line.y_shunt_km)
     branch_dict["b_fr"] = imag(line.y_shunt_km)
-    branch_dict["br_r"] = real(1 / line.Y)
-    branch_dict["br_x"] = imag(1 / line.Y)
+    branch_dict["br_r"] = real(1 / line.y)
+    branch_dict["br_x"] = imag(1 / line.y)
     branch_dict["g_to"] = real(line.y_shunt_mk)
     branch_dict["b_to"] = imag(line.y_shunt_mk)
 end
 
 
 function power_flow(power_grid::PowerGrid)
-    # TODO write a wrapper for mapping dict strings to integer lists and remmeber it for mapping back the results to string bus names
+    # TODO write a wrapper for mapping dict strings to integer lists and remember it for mapping back the results to string bus names
     global ang_min, ang_max
     ang_min = deg2rad(60)
     ang_max = deg2rad(-60)


### PR DESCRIPTION
Hey,

I wanted to use the `solve_powerflow = true` option for my work and stumbled across a bug for the `PiModelLine` while doing so.

In the power flow calculation of the `PiModelLine` and the `Transformer` the admittance is accessed by `line.Y` which is the wrong parameter name for these lines:
https://github.com/JuliaEnergy/PowerDynamics.jl/blob/main/src/operationpoint/power_flow.jl#L217

I have changed it to `line.y` and now the following code is working:

```
n = [SwingEqLVS(H = 5., P = 1., D = 0.1, Ω = 50, Γ = 0.1, V = 1.), SwingEqLVS(H = 5., P = -1., D = 0.1, Ω = 50, Γ = 0.1, V = 1.)]
l = [PiModelLine(from = 1, to = 2, y = -13im, y_shunt_km=0.0, y_shunt_mk = 0.0)]

pg = PowerGrid(n, l)
find_operationpoint(pg, solve_powerflow = true)
```

Maybe there should also be more tests for the PowerModels.jl integration in the future? 