### PR TITLE
check allocations in smoketest and warn

### DIFF
--- a/test/nodes/NodeTestBase.jl
+++ b/test/nodes/NodeTestBase.jl
@@ -1,14 +1,19 @@
-du,u,i = rand(ComplexF64, 3)
-t = rand(0.1:10.0)
-
 function smoketest_rhs(vertex; int_x=[], int_dx=[])
+    du,u,i = rand(ComplexF64, 3)
+    t = rand(0.1:10.0)
+
     dx = [real(du), imag(du)]
     x = [real(u), imag(u)]
     append!(x, int_x)
     append!(dx, int_dx)
     edges = [[real(i), imag(i), real(i), imag(i)]]
-    p = []
-    vertex.f(dx, x, edges, p, t)
+    p = nothing
+    vertex.f(dx, x, edges, p, t) # first call for precompilation
+
+    allocations = @allocated vertex.f(dx, x, edges, p, t)
+    if allocations != 0
+        @warn "RHS shows non-zero ($allocations) allocations!"
+    end
 end
 
 function rand_real()


### PR DESCRIPTION
Currently allocating nodes are:
```
┌ Warning: RHS shows non-zero (208) allocations!
└ @ Main ~/.julia/dev/PowerDynamics/test/nodes/NodeTestBase.jl:15
CompositeNode Node Tests: 1.270691916 s

┌ Warning: RHS shows non-zero (80) allocations!
└ @ Main ~/.julia/dev/PowerDynamics/test/nodes/NodeTestBase.jl:15
WindGenType 4 Tests: 0.12561925 s

┌ Warning: RHS shows non-zero (240) allocations!
└ @ Main ~/.julia/dev/PowerDynamics/test/nodes/NodeTestBase.jl:15
WindGenType 4 with Rotor Control Tests: 0.130974833 s

┌ Warning: RHS shows non-zero (160) allocations!
└ @ Main ~/.julia/dev/PowerDynamics/test/nodes/NodeTestBase.jl:15
CurtailedPowerPlantWithInertia Tests: 0.121670833 s
```
(the warning is allways displayed **above** the test result.

All of them are experimental so i guess it does not matter to much
