### PR TITLE
Parsing for parameter-arrays

### DIFF
--- a/src/parsers/JsonParser.jl
+++ b/src/parsers/JsonParser.jl
@@ -77,6 +77,8 @@ function convert_node(node)
         node = ExponentialRecoveryLoad(;sym_params...)
     elseif type == "VoltageDependentLoad"
         node = VoltageDependentLoad(;sym_params...)
+    elseif type == "NormalForm"
+        node = NormalForm(;sym_params...)
     else
         throw(ArgumentError("Invalid type: $type"))
     end

--- a/src/parsers/JsonParser.jl
+++ b/src/parsers/JsonParser.jl
@@ -50,7 +50,7 @@ function convert_node(node)
     name = get(node, "name", nothing)
     type = get(node, "type", nothing)
     params = get(node, "params", [])
-    sym_params = Dict(Symbol(k) => _map_complex(v) for (k, v) in params)
+    sym_params = Dict(Symbol(k) => _map_array(v) for (k, v) in params)
     if type == "SwingEq"
         node = SwingEq(;sym_params...)
     elseif type == "SwingEqLVS"
@@ -119,6 +119,17 @@ function _map_complex(v)
         Complex(get(v, "re", nothing), get(v, "im", nothing))
     else
         v
+    end
+end
+
+function _map_array(v)
+    if isa(v,Vector) && all(isa.(v,Vector))
+        M = [v...;;]
+        _map_complex.(M)
+    elseif isa(v,Vector)
+        _map_complex.(v)
+    else
+        _map_complex(v)
     end
 end
 

--- a/test/parsers/JsonParser.jl
+++ b/test/parsers/JsonParser.jl
@@ -1,7 +1,4 @@
-using PowerDynamics:
-    read_powergrid,
-    write_powergrid,
-    Json
+using PowerDynamics: read_powergrid, write_powergrid, Json, PowerGrid, NormalForm
 using OrderedCollections: OrderedDict
 using Test: @test, @test_throws
 
@@ -140,3 +137,25 @@ dict_grid = read_powergrid(dict_export_file, Json)
     joinpath(@__DIR__, "grid_with_invalid_params.json"),
     Json,
 )
+
+# test parsing of parameter-arrays
+
+P, Q, V = rand(3)
+Bᵤ = 1im*rand(2)
+Cᵤ, Gᵤ, Hᵤ = 1im*rand(3)
+Bₓ = rand(2,2)
+Cₓ = rand(2)
+Gₓ = rand(2)
+Hₓ = rand(2)
+
+nodes = [
+    NormalForm(P=P, Q=Q, V=V, Bᵤ=Bᵤ, Cᵤ=Cᵤ, Gᵤ=Gᵤ, Hᵤ=Hᵤ, Bₓ=Bₓ, Cₓ=Cₓ, Gₓ=Gₓ, Hₓ=Hₓ)
+]
+
+pg = PowerGrid(nodes,[])
+
+file = joinpath(@__DIR__,"testgrid.json")
+write_powergrid(pg, file, Json)
+pg_read = read_powergrid(file, Json)
+@test pg_read.nodes == pg.nodes
+rm(file)


### PR DESCRIPTION
The parser can now handle arrays of complex parameters as well as parameters of type `Matrix`. (Note: Matrices are saved as nested arrays in the .json-files).